### PR TITLE
Fix error reading monitrc

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
   template:
     src: "etc_monit_monitrc.j2"
     dest: "/etc/monit/monitrc"
+    mode: 0400
   notify:
     - restart monit
 


### PR DESCRIPTION
Fixes the monit complaint:

```
The control file '/etc/monit/monitrc' must have permissions no more than -rwx------ (0700); right now permissions are -rw-r--r-- (0644).
```